### PR TITLE
More work; 3 commits in a single PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+TULPACKAGE*
+out/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "search.useIgnoreFiles": false,
+    "search.exclude": {
+        "bin": true,
+        "obj": true
+    }
+}

--- a/Helpers/Utils.cs
+++ b/Helpers/Utils.cs
@@ -66,6 +66,11 @@ namespace Altinn2Convert.Helpers
                 absolutePath.Append(item + "/");
             }
 
+            if (absolutePath.Length == 0)
+            {
+                throw new Exception("Invalid xpath: " + path);
+            }
+
             absolutePath.Remove(absolutePath.Length - 1, 1); // remove the last "/" since we allways add an extra "/" at the end in the construction phase.            
 
             return absolutePath.ToString();


### PR DESCRIPTION
### Add TULPACKAGE and out/ to gitignore for local testing
Also set settings to not use .gitignore for global search, but exclude
"bin" and "obj" directories

### Get the filename for output folders from manifest.xml
This means you don't have to rename your downloaded TUL packages
in order to have sensible names in the output.

### Lots of fixes to parsing
* Introduce a Converter state instead of passing more and more variables to all functions
* Use xpath based ids on groups and headers to reduce git diffs for result when we add or remove elements.
* support xpathPrefix for templates and repeating groups
* handle <table and <tr elements the same as everything else. (they were different for stupid reasons.)
